### PR TITLE
Add mutual authentication with self-signed certificate

### DIFF
--- a/certificate-authentication.tf
+++ b/certificate-authentication.tf
@@ -1,0 +1,117 @@
+resource "tls_private_key" "ca" {
+  count = var.authentication_type == local.certificate_authentication ? 1 : 0
+
+  algorithm = "RSA"
+}
+
+resource "tls_self_signed_cert" "ca" {
+  count = var.authentication_type == local.certificate_authentication ? 1 : 0
+
+  key_algorithm   = "RSA"
+  private_key_pem = tls_private_key.ca[0].private_key_pem
+
+  subject {
+    common_name  = "${var.certificate_authentication["organization"]}.vpn.ca"
+    organization = var.certificate_authentication["organization"]
+  }
+
+  validity_period_hours = 87600 # ten years
+  is_ca_certificate     = true
+
+  allowed_uses = [
+    "cert_signing",
+    "crl_signing",
+  ]
+}
+
+resource "aws_acm_certificate" "ca" {
+  count = var.authentication_type == local.certificate_authentication ? 1 : 0
+
+  private_key      = tls_private_key.ca[0].private_key_pem
+  certificate_body = tls_self_signed_cert.ca[0].cert_pem
+}
+
+resource "tls_private_key" "root" {
+  count = var.authentication_type == local.certificate_authentication ? 1 : 0
+
+  algorithm = "RSA"
+}
+
+resource "tls_cert_request" "root" {
+  count = var.authentication_type == local.certificate_authentication ? 1 : 0
+
+  key_algorithm   = "RSA"
+  private_key_pem = tls_private_key.root[0].private_key_pem
+  subject {
+    common_name  = "${var.certificate_authentication["organization"]}.vpn.client"
+    organization = var.certificate_authentication["organization"]
+  }
+}
+
+resource "tls_locally_signed_cert" "root" {
+  count = var.authentication_type == local.certificate_authentication ? 1 : 0
+
+  cert_request_pem   = tls_cert_request.root[0].cert_request_pem
+  ca_key_algorithm   = "RSA"
+  ca_private_key_pem = tls_private_key.ca[0].private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.ca[0].cert_pem
+
+  validity_period_hours = 87600
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "client_auth",
+  ]
+}
+
+resource "aws_acm_certificate" "root" {
+  count = var.authentication_type == local.certificate_authentication ? 1 : 0
+
+  private_key       = tls_private_key.root[0].private_key_pem
+  certificate_body  = tls_locally_signed_cert.root[0].cert_pem
+  certificate_chain = tls_self_signed_cert.ca[0].cert_pem
+}
+
+resource "tls_private_key" "server" {
+  count = var.authentication_type == local.certificate_authentication ? 1 : 0
+
+  algorithm = "RSA"
+}
+
+resource "tls_cert_request" "server" {
+  count = var.authentication_type == local.certificate_authentication ? 1 : 0
+
+  key_algorithm   = "RSA"
+  private_key_pem = tls_private_key.server[0].private_key_pem
+
+  subject {
+    common_name  = "${var.certificate_authentication["organization"]}.vpn.client"
+    organization = var.certificate_authentication["organization"]
+  }
+}
+
+resource "tls_locally_signed_cert" "server" {
+  count = var.authentication_type == local.certificate_authentication ? 1 : 0
+
+  cert_request_pem   = tls_cert_request.server[0].cert_request_pem
+  ca_key_algorithm   = "RSA"
+  ca_private_key_pem = tls_private_key.ca[0].private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.ca[0].cert_pem
+
+  validity_period_hours = 87600
+
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+}
+
+resource "aws_acm_certificate" "server" {
+  count = var.authentication_type == local.certificate_authentication ? 1 : 0
+
+  private_key       = tls_private_key.server[0].private_key_pem
+  certificate_body  = tls_locally_signed_cert.server[0].cert_pem
+  certificate_chain = tls_self_signed_cert.ca[0].cert_pem
+}

--- a/certificate.tf
+++ b/certificate.tf
@@ -7,6 +7,8 @@ data "aws_route53_zone" "current" {
 }
 
 resource "aws_route53_record" "default" {
+  count = var.authentication_type == local.federated_authentication ? 1 : 0
+
   zone_id = var.zone_id
   name    = local.dns_name
   type    = "CNAME"
@@ -14,10 +16,17 @@ resource "aws_route53_record" "default" {
   records = [aws_ec2_client_vpn_endpoint.default.dns_name]
 }
 
+# For "federated-authentication" generate a AWS managed certificate
 resource "aws_acm_certificate" "default" {
+  count = var.authentication_type == local.federated_authentication ? 1 : 0
+
   domain_name       = local.dns_name
   validation_method = "DNS"
   tags              = var.tags
+
+  options {
+    certificate_transparency_logging_preference = "ENABLED"
+  }
 
   lifecycle {
     create_before_destroy = true
@@ -27,14 +36,46 @@ resource "aws_acm_certificate" "default" {
 # Pending https://github.com/terraform-providers/terraform-provider-aws/issues/14447
 # workaround -> https://github.com/terraform-providers/terraform-provider-aws/issues/14447#issuecomment-668766123
 resource "aws_route53_record" "certificate_validation" {
-  name    = aws_acm_certificate.default.domain_validation_options.*.resource_record_name[0]
-  records = [aws_acm_certificate.default.domain_validation_options.*.resource_record_value[0]]
+  count = var.authentication_type == local.federated_authentication ? 1 : 0
+
+  name    = aws_acm_certificate.default[0].domain_validation_options.*.resource_record_name[0]
+  records = [aws_acm_certificate.default[0].domain_validation_options.*.resource_record_value[0]]
   ttl     = 60
-  type    = aws_acm_certificate.default.domain_validation_options.*.resource_record_type[0]
+  type    = aws_acm_certificate.default[0].domain_validation_options.*.resource_record_type[0]
   zone_id = var.zone_id
 }
 
 resource "aws_acm_certificate_validation" "default" {
-  certificate_arn         = aws_acm_certificate.default.arn
-  validation_record_fqdns = [aws_route53_record.certificate_validation.fqdn]
+  count = var.authentication_type == local.federated_authentication ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.default[0].arn
+  validation_record_fqdns = [aws_route53_record.certificate_validation[0].fqdn]
+}
+
+# For "certificate-authentication" generate a "self-signed" certificate
+resource "tls_self_signed_cert" "default" {
+  count = var.authentication_type == local.certificate_authentication ? 1 : 0
+
+  key_algorithm   = "RSA"
+  private_key_pem = var.certificate_authentication["private_key_pem"]
+
+  subject {
+    common_name  = local.dns_name
+    organization = var.certificate_authentication["organization"]
+  }
+
+  validity_period_hours = 8760 # 1 year
+
+  allowed_uses = [
+    "digital_signature",
+    "key_encipherment",
+    "server_auth",
+  ]
+}
+
+resource "aws_acm_certificate" "self_signed" {
+  count = var.authentication_type == local.certificate_authentication ? 1 : 0
+
+  private_key      = var.certificate_authentication["private_key_pem"]
+  certificate_body = tls_self_signed_cert.default[0].cert_pem
 }

--- a/federated-authentication.tf
+++ b/federated-authentication.tf
@@ -51,31 +51,3 @@ resource "aws_acm_certificate_validation" "default" {
   certificate_arn         = aws_acm_certificate.default[0].arn
   validation_record_fqdns = [aws_route53_record.certificate_validation[0].fqdn]
 }
-
-# For "certificate-authentication" generate a "self-signed" certificate
-resource "tls_self_signed_cert" "default" {
-  count = var.authentication_type == local.certificate_authentication ? 1 : 0
-
-  key_algorithm   = "RSA"
-  private_key_pem = var.certificate_authentication["private_key_pem"]
-
-  subject {
-    common_name  = local.dns_name
-    organization = var.certificate_authentication["organization"]
-  }
-
-  validity_period_hours = 8760 # 1 year
-
-  allowed_uses = [
-    "digital_signature",
-    "key_encipherment",
-    "server_auth",
-  ]
-}
-
-resource "aws_acm_certificate" "self_signed" {
-  count = var.authentication_type == local.certificate_authentication ? 1 : 0
-
-  private_key      = var.certificate_authentication["private_key_pem"]
-  certificate_body = tls_self_signed_cert.default[0].cert_pem
-}

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_log_stream" "default" {
 
 resource "aws_ec2_client_vpn_endpoint" "default" {
   client_cidr_block      = var.client_cidr_block
-  server_certificate_arn = try(aws_acm_certificate.self_signed[0].arn, aws_acm_certificate.default[0].arn)
+  server_certificate_arn = try(aws_acm_certificate.server[0].arn, aws_acm_certificate.default[0].arn)
   split_tunnel           = var.split_tunnel
   description            = var.stack
   dns_servers            = var.dns_servers
@@ -24,7 +24,7 @@ resource "aws_ec2_client_vpn_endpoint" "default" {
 
   authentication_options {
     type                       = var.authentication_type
-    root_certificate_chain_arn = try(aws_acm_certificate.self_signed[0].arn, null)
+    root_certificate_chain_arn = try(aws_acm_certificate.root[0].arn, null)
     saml_provider_arn          = try(aws_iam_saml_provider.default[0].arn, null)
   }
 

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ locals {
 }
 
 resource "aws_cloudwatch_log_group" "default" {
-  name = "/aws/clientvpn"
+  name = "/aws/clientvpn/${var.stack}"
   tags = var.tags
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,7 @@ output "endpoint_id" {
 output "security_group_id" {
   value = aws_security_group.default.id
 }
+
+output "self_signed_cert_body_pem" {
+  value = var.authentication_type == local.certificate_authentication ? tls_self_signed_cert.default[0].cert_pem : null
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,5 +7,7 @@ output "security_group_id" {
 }
 
 output "self_signed_cert_body_pem" {
-  value = var.authentication_type == local.certificate_authentication ? tls_self_signed_cert.default[0].cert_pem : null
+  value = var.authentication_type == local.certificate_authentication ? aws_acm_certificate.self_signed[0].certificate_body : null
 }
+
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,12 +2,14 @@ output "endpoint_id" {
   value = aws_ec2_client_vpn_endpoint.default.id
 }
 
+output "root_cert_body_pem" {
+  value = var.authentication_type == local.certificate_authentication ? aws_acm_certificate.root[0].certificate_body : null
+}
+
+output "root_cert_private_key" {
+  value = var.authentication_type == local.certificate_authentication ? aws_acm_certificate.root[0].private_key : null
+}
+
 output "security_group_id" {
   value = aws_security_group.default.id
 }
-
-output "self_signed_cert_body_pem" {
-  value = var.authentication_type == local.certificate_authentication ? aws_acm_certificate.self_signed[0].certificate_body : null
-}
-
-

--- a/saml.tf
+++ b/saml.tf
@@ -1,13 +1,17 @@
 resource "aws_iam_saml_provider" "default" {
+  count = var.authentication_type == local.federated_authentication ? 1 : 0
+
   name                   = "Okta-${var.stack}-ClientVPN"
-  saml_metadata_document = okta_app_saml.default.metadata
+  saml_metadata_document = okta_app_saml.default[0].metadata
 }
 
 resource "okta_app_saml" "default" {
+  count = var.authentication_type == local.federated_authentication ? 1 : 0
+
   app_settings_json = "{\"port\": 35001}"
   hide_ios          = true
   hide_web          = true
-  label             = var.okta_label
+  label             = try(var.federated_authentication["okta_label"], null)
   preconfigured_app = "aws_clientvpn"
 
   lifecycle {
@@ -16,9 +20,9 @@ resource "okta_app_saml" "default" {
 }
 
 resource "okta_app_group_assignment" "default" {
-  for_each = toset(var.okta_groups)
+  for_each = try(toset(var.federated_authentication["okta_groups"]), {})
 
-  app_id   = okta_app_saml.default.id
+  app_id   = okta_app_saml.default[0].id
   group_id = each.key
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -36,8 +36,7 @@ variable "federated_authentication" {
 
 variable "certificate_authentication" {
   type = object({
-    organization    = string
-    private_key_pem = string
+    organization         = string
   })
   default     = null
   description = "Implements Certificate (Mutual) Authentication using self-signed certificates. Required when var.authentication_type is 'certificate-authentication'"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,13 @@
+variable "authentication_type" {
+  type        = string
+  description = "Type of authentication used"
+
+  validation {
+    condition     = anytrue([var.authentication_type == "certificate-authentication", var.authentication_type == "federated-authentication"])
+    error_message = "Must be either 'federated-authentication' or 'certificate-authentication'."
+  }
+}
+
 variable "client_cidr_block" {
   type        = string
   description = "The CIDR to use for the clients"
@@ -15,16 +25,22 @@ variable "dns_servers" {
   description = "A Client VPN endpoint can have up to two DNS servers"
 }
 
-variable "okta_groups" {
-  type        = list(string)
-  default     = []
-  description = "List of Okta group IDs to have the VPN assigned"
+variable "federated_authentication" {
+  type = object({
+    okta_groups = list(string)
+    okta_label  = string
+  })
+  default     = null
+  description = "Implements Federated Athentication using OKTA. Required when var.authentication_type is 'federated-authentication'"
 }
 
-variable "okta_label" {
-  type        = string
-  default     = "Client VPN"
-  description = "The label of the Okta App"
+variable "certificate_authentication" {
+  type = object({
+    organization    = string
+    private_key_pem = string
+  })
+  default     = null
+  description = "Implements Certificate (Mutual) Authentication using self-signed certificates. Required when var.authentication_type is 'certificate-authentication'"
 }
 
 variable "split_tunnel" {
@@ -63,4 +79,3 @@ variable "zone_id" {
   type        = string
   description = "ID of the Route53 zone in which to create the subdomain record"
 }
-

--- a/versions.tf
+++ b/versions.tf
@@ -9,5 +9,5 @@ terraform {
       version = ">= 3.5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
 }


### PR DESCRIPTION
- Add support for mutual authentication in order to connect with OpenVPN client using self-signed certificates.
- Explicitely state the authentication type: either 'federated-authentication' (with OKTA as SAML IdP)
or 'mutual-authentication' with self-signed certificates signed with aprovided private key.